### PR TITLE
additional error handling

### DIFF
--- a/src/handlers/workflow-proxy.ts
+++ b/src/handlers/workflow-proxy.ts
@@ -32,7 +32,6 @@ export function proxyWorkflowCallbacks(context: Context): ProxyCallbacks {
           for (const r of res) {
             if (r.status !== 200) {
               await bubbleUpErrorComment(context, new Error(r.reason));
-              await exit(1);
             }
           }
           await exit(0);

--- a/src/types/plugin-context-single.ts
+++ b/src/types/plugin-context-single.ts
@@ -82,11 +82,11 @@ export class PluginContext {
    * This can be used with events from both Telegram and GitHub, this token comes from
    * the worker's environment variables i.e the Storage App.
    */
-  async getTelegramEventOctokit(): Promise<RestOctokitFromApp> {
+  async getTelegramEventOctokit(): Promise<RestOctokitFromApp | null> {
     let octokit: RestOctokitFromApp | null = null;
 
     try {
-      await this.getApp().eachInstallation(async (installation) => {
+      await this.getApp().eachInstallation((installation) => {
         if (installation.installation.account?.login === this.config.storageOwner) {
           octokit = installation.octokit;
         }
@@ -94,9 +94,7 @@ export class PluginContext {
     } catch (er) {
       logger.error("Error initializing octokit in getTelegramEventOctokit", { er });
     }
-    if (!octokit) {
-      throw new Error("Octokit could not be initialized");
-    }
+
     return octokit;
   }
 

--- a/src/types/plugin-context-single.ts
+++ b/src/types/plugin-context-single.ts
@@ -85,12 +85,15 @@ export class PluginContext {
   async getTelegramEventOctokit(): Promise<RestOctokitFromApp> {
     let octokit: RestOctokitFromApp | null = null;
 
-    await this.getApp().eachInstallation(async (installation) => {
-      if (installation.installation.account?.login === this.config.storageOwner) {
-        octokit = installation.octokit;
-      }
-    });
-
+    try {
+      await this.getApp().eachInstallation(async (installation) => {
+        if (installation.installation.account?.login === this.config.storageOwner) {
+          octokit = installation.octokit;
+        }
+      });
+    } catch (er) {
+      logger.error("Error initializing octokit in getTelegramEventOctokit", { er });
+    }
     if (!octokit) {
       throw new Error("Octokit could not be initialized");
     }

--- a/src/types/plugin-context-single.ts
+++ b/src/types/plugin-context-single.ts
@@ -87,7 +87,7 @@ export class PluginContext {
 
     try {
       await this.getApp().eachInstallation((installation) => {
-        if (installation.installation.account?.login === this.config.storageOwner) {
+        if (installation.installation.account?.login.toLowerCase() === this.config.storageOwner.toLowerCase()) {
           octokit = installation.octokit;
         }
       });

--- a/src/types/plugin-context-single.ts
+++ b/src/types/plugin-context-single.ts
@@ -23,12 +23,14 @@ export class PluginContext {
     public readonly inputs: PluginInputs,
     public _env: Env
   ) {
+    // this will fallback to defaults if it's a telegram bot command
     this._config = this.inputs.settings;
   }
 
   get env() {
     return Value.Decode(envValidator.schema, Value.Default(envValidator.schema, this._env));
   }
+
   set env(env: Env) {
     this._env = env;
   }

--- a/src/types/telegram-bot-single.ts
+++ b/src/types/telegram-bot-single.ts
@@ -23,6 +23,10 @@ export class TelegramBotSingleton {
 
     const octokit = await PluginContext.getInstance().getTelegramEventOctokit();
 
+    if (!octokit) {
+      throw new Error("octokit could not be initialized");
+    }
+
     if (!TelegramBotSingleton._instance) {
       TelegramBotSingleton._instance = new TelegramBotSingleton();
       try {

--- a/src/types/telegram-bot-single.ts
+++ b/src/types/telegram-bot-single.ts
@@ -1,3 +1,4 @@
+import { Octokit } from "octokit";
 import { Env } from ".";
 import { Bot, createBot } from "../bot";
 import { createServer } from "../server";
@@ -21,10 +22,16 @@ export class TelegramBotSingleton {
       },
     } = env;
 
-    const octokit = await PluginContext.getInstance().getTelegramEventOctokit();
+    let octokit: Octokit | null = null;
+
+    try {
+      octokit = await PluginContext.getInstance().getTelegramEventOctokit();
+    } catch (er) {
+      logger.error("Error initializing octokit in TelegramBotSingleton", { er });
+    }
 
     if (!octokit) {
-      throw new Error("octokit could not be initialized");
+      throw new Error("Octokit not initialized");
     }
 
     if (!TelegramBotSingleton._instance) {


### PR DESCRIPTION
Relates to #13 

I'm debugging in the dark here because

1. My cf webhook url now sets instantly for me but not the ubiquity one
2. I can't see cloudflare logs. If I can get access scoped to this worker (and the kernel would be good) that would be great.
3. I'm guessing at what's happening between the kernel and worker
4. Things work smoothly for me, I'm making assumptions which is why I'm adding more error handling for whoever needs to read the cloudflare logs for me


Notifications working for me and the CF log for the notification which succeeded:
![image](https://github.com/user-attachments/assets/2dae3574-8707-450d-9764-96d5056a9a22)


I'll continue to just debug in the dark until it's working it can only be a few reasons I'm thinking but my life would be easier and development of this plugin faster if I had the correct access.
