### PR TITLE
Command input in action

### DIFF
--- a/.github/workflows/compute.yml
+++ b/.github/workflows/compute.yml
@@ -17,6 +17,8 @@ on:
         description: "Ref"
       signature:
         description: "Signature to identify the Kernel"
+      command:
+        description: "Command"
 
 jobs:
   compute:


### PR DESCRIPTION
Related to https://github.com/ubiquity-os/ubiquity-os-kernel/pull/186

This just adds input to the action so it doesn't fail but the plugin doesn't actually use any commands (yet).
I will also convert it to SDK but it's more complex because it's a hybrid plugin